### PR TITLE
ci: Update version to 0.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vott-react",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "author": "VOTT Team vott@microsoft.com>",
     "description": "Reusable React components originally designed for VOTT app",
     "license": "MIT",


### PR DESCRIPTION
There seems to be a collision in the CI when trying to build 0.2.3. Going to start the process over with a `0.2.4` tag and see if that builds