### PR TITLE
ci: "test:coverage"

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "pretest": "npm run lint",
         "test": "react-scripts test --env=jsdom --silent",
         "test:ci": "set CI=true && npm run test",
-        "test:coverage": "react-scripts test --coverage",
+        "test:coverage": "npm run test -- --coverage",
         "eject": "react-scripts eject",
         "clean": "rm -rf dist",
         "prebuild": "npm run lint",

--- a/src/components/tagsInput/tagsInput.tsx
+++ b/src/components/tagsInput/tagsInput.tsx
@@ -95,7 +95,7 @@ export class TagsInput extends React.Component<ITagsInputProps, ITagsInputState>
     public componentDidMount() {
         this.setState({
             currentTagColorIndex: randomIntInRange(0, this.getTagColorKeys().length),
-        })
+        });
     }
 
     public componentDidUpdate(prevProps: ITagsInputProps) {


### PR DESCRIPTION
ci: "test:coverage"

This fixes the test:coverage command. This makes sure we run lint before testing.