### PR TITLE
fix: Handle adding tag where no tags already exist [AB#17421]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vott-react",
-    "version": "0.2.7",
+    "version": "0.2.8",
     "author": "VOTT Team vott@microsoft.com>",
     "description": "Reusable React components originally designed for VOTT app",
     "license": "MIT",

--- a/src/components/tagsInput/tagsInput.test.tsx
+++ b/src/components/tagsInput/tagsInput.test.tsx
@@ -78,7 +78,7 @@ describe("Tags Input Component", () => {
             tags: null,
             onChange: onChangeHandler,
         });
-        const newTagName = "My new tag"
+        const newTagName = "My new tag";
         wrapper.find("input").simulate("change", { target: { value: newTagName } });
         wrapper.find("input").simulate("keyDown", { keyCode: KeyCodes.enter });
         expect(onChangeHandler).toBeCalled();

--- a/src/components/tagsInput/tagsInput.test.tsx
+++ b/src/components/tagsInput/tagsInput.test.tsx
@@ -72,6 +72,20 @@ describe("Tags Input Component", () => {
         expect(colorValues).toContain(wrapper.find(TagsInput).state().tags[newTagIndex].color);
     });
 
+    it("create a new tag with no existing tags", () => {
+        const onChangeHandler = jest.fn();
+        const wrapper = createComponent({
+            tags: null,
+            onChange: onChangeHandler,
+        });
+        const newTagName = "My new tag"
+        wrapper.find("input").simulate("change", { target: { value: newTagName } });
+        wrapper.find("input").simulate("keyDown", { keyCode: KeyCodes.enter });
+        expect(onChangeHandler).toBeCalled();
+        expect(wrapper.find(TagsInput).state().tags).toHaveLength(1);
+        expect(wrapper.find(TagsInput).state().tags[0].name).toEqual(newTagName);
+    });
+
     it("create a new tag from text box - comma key", () => {
         const onChangeHandler = jest.fn();
         const wrapper = createComponent({

--- a/src/components/tagsInput/tagsInput.tsx
+++ b/src/components/tagsInput/tagsInput.tsx
@@ -246,9 +246,10 @@ export class TagsInput extends React.Component<ITagsInputProps, ITagsInputState>
         const tagColors = this.getTagColors();
         const tagColorKeys = Object.keys(tagColors);
         tag.color = tagColors[tagColorKeys[this.state.currentTagColorIndex]];
+        const currentTags = (this.state.tags && this.state.tags.length) ? this.state.tags : [];
         this.setState((prevState) => {
             return {
-                tags: [...this.state.tags, tag],
+                tags: [...currentTags, tag],
                 currentTagColorIndex: (prevState.currentTagColorIndex + 1) % tagColorKeys.length,
             };
         }, () => this.props.onChange(this.state.tags));


### PR DESCRIPTION
- This resolves an invalid spread operation that happens when there are no existing tags in the TagsInput state (non-iterable)
- Adds a unit test to verify this
- Bumps package version