### PR TITLE
fix: remove grey and white from tagcolors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vott-react",
-    "version": "0.2.8",
+    "version": "0.2.9",
     "author": "VOTT Team vott@microsoft.com>",
     "description": "Reusable React components originally designed for VOTT app",
     "license": "MIT",

--- a/src/components/common/tagColors.ts
+++ b/src/components/common/tagColors.ts
@@ -1,6 +1,4 @@
 export const tagColors = {
-    White: "#FFFFFF",
-    Gray: "#808080",
     Red: "#FF0000",
     Maroon: "#800000",
     Yellow: "#FFFF00",


### PR DESCRIPTION
Tags with grey and white colors associated with them are not recognized by canvas tools and therefore are rendered in the editorPage as red. Eliminating these colors to fix the bug.