### PR TITLE
fix: lock tag on mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# ide
+.idea/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vott-react",
-  "version": "0.2.2",
+  "version": "0.2.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/tagsInput/tagsInput.tsx
+++ b/src/components/tagsInput/tagsInput.tsx
@@ -165,7 +165,7 @@ export class TagsInput extends React.Component<ITagsInputProps, ITagsInputState>
         const tag: ITag = this.getTag(text);
         if (this.props.onCtrlShiftTagClick && event.ctrlKey && event.shiftKey) {
             this.props.onCtrlShiftTagClick(tag);
-        } else if (this.props.onCtrlTagClick && event.ctrlKey) {
+        } else if (this.props.onCtrlTagClick && (event.ctrlKey || event.metaKey)) {
             this.props.onCtrlTagClick(tag);
         } else if (this.props.onShiftTagClick && event.shiftKey) {
             this.props.onShiftTagClick(tag);


### PR DESCRIPTION
On mac, ctrl does not trigger a keyboard event, but cmd does.

Fix is adding a listener for the cmd key which is the metakey.

AB#17465